### PR TITLE
Update build.gradle

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -5,7 +5,6 @@ apply plugin: 'kotlin-android'
 
 android {
     compileSdk 34
-    buildToolsVersion "31.0.0"
     namespace "li.power.app.wearos.teslanak"
 
     defaultConfig {


### PR DESCRIPTION
```
WARNING: The specified Android SDK Build Tools version (31.0.0) is ignored, as it is below the minimum supported version (34.0.0) for Android Gradle Plugin 8.2.2.
Android SDK Build Tools 34.0.0 will be used.
To suppress this warning, remove "buildToolsVersion '31.0.0'" from your build.gradle file, as each version of the Android Gradle Plugin now has a default version of the build tools.
WARNING: The specified Android SDK Build Tools version (31.0.0) is ignored, as it is below the minimum supported version (34.0.0) for Android Gradle Plugin 8.2.2.
Android SDK Build Tools 34.0.0 will be used.
To suppress this warning, remove "buildToolsVersion '31.0.0'" from your build.gradle file, as each version of the Android Gradle Plugin now has a default version of the build tools.
```