### PR TITLE
Update AndroidManifest.xml

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-          package="li.power.app.wearos.teslanak">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <uses-permission android:name="android.permission.NFC" />
     <uses-feature android:name="android.hardware.type.watch"/>


### PR DESCRIPTION
```
package="li.power.app.wearos.teslanak" found in source AndroidManifest.xml: /home/runner/work/TeslaWearKey/TeslaWearKey/app/src/main/AndroidManifest.xml.
Setting the namespace via the package attribute in the source AndroidManifest.xml is no longer supported, and the value is ignored.
Recommendation: remove package="li.power.app.wearos.teslanak" from the source AndroidManifest.xml: /home/runner/work/TeslaWearKey/TeslaWearKey/app/src/main/AndroidManifest.xml.
```